### PR TITLE
Add support for multiple EC sensors

### DIFF
--- a/DFRobot_EC.cpp
+++ b/DFRobot_EC.cpp
@@ -34,6 +34,51 @@
 #define RES2 820.0
 #define ECREF 200.0
 
+// Maps the pin (A0,A1..A11) to a number 0-11 so the address can be determined
+uint8_t mapECPin(uint8_t ecPin)
+{
+    int addressMap = 0;
+    if (ecPin == A0){
+        Serial.print(" pin A0 ");
+        addressMap = 0;
+    } else if (ecPin == A1){
+        Serial.print(" pin A1 ");
+        addressMap = 1;
+    } else if (ecPin == A2){
+        Serial.print(" pin A2 ");
+        addressMap = 2;
+    } else if (ecPin == A3){
+        Serial.print(" pin A3 ");
+        addressMap = 3;
+    } else if (ecPin == A4){
+        Serial.print(" pin A4 ");
+        addressMap = 4;
+    } else if (ecPin == A5){
+        Serial.print(" pin A5 ");
+        addressMap = 5;
+    } else if (ecPin == A6){
+        Serial.print(" pin A6 ");
+        addressMap = 6;
+    } else if (ecPin == A7){
+        Serial.print(" pin A7 ");
+        addressMap = 7;
+    } else if (ecPin == A8){
+        Serial.print(" pin A8 ");
+        addressMap = 8;
+    } else if (ecPin == A9){
+        Serial.print(" pin A9 ");
+        addressMap = 9;
+    } else if (ecPin == A10){
+        Serial.print(" pin A10 ");
+        addressMap = 10;
+    } else if (ecPin == A11){
+        Serial.print(" pin A11 ");
+        addressMap = 11;
+    }
+
+    return addressMap;
+}
+
 // Default construtor to ensure backwards compatibility
 DFRobot_EC::DFRobot_EC()
 {
@@ -45,7 +90,7 @@ DFRobot_EC::DFRobot_EC()
     // This will be 8byte per sensor and the largest arduino has 12 analogue ports
     // So let's start at address 0 and go up by 8b for each analogue port. This will use upto 96b 
     // For the EC library we will start after PH addresses
-    this->_address        = KVALUEADDR + (sizeof(float) * 2 * EPinToAddressMap[this->_pin]);
+    this->_address        = KVALUEADDR + (sizeof(float) * 2 * mapECPin(this->_pin));
 
     // Buffer solution EC 1.413us/cm at 25C
     this->_kvalueLow              = 1.0;
@@ -62,7 +107,7 @@ DFRobot_EC::DFRobot_EC()
 } 
 
 // Updated construtor to allow multiple EC sensors
-DFRobot_EC::DFRobot_EC(int ecPin);
+DFRobot_EC::DFRobot_EC(int ecPin)
 {
     // Set the pin to the supplied value
     this->_pin                    = ecPin;
@@ -72,7 +117,7 @@ DFRobot_EC::DFRobot_EC(int ecPin);
     // This will be 8byte per sensor and the largest arduino has 12 analogue ports
     // So let's start at address 0 and go up by 8b for each analogue port. This will use upto 96b 
     // For the EC library we will start after PH addresses
-    this->_address                = KVALUEADDR + (sizeof(float) * 2 * EPinToAddressMap[this->_pin]);
+    this->_address                = KVALUEADDR + (sizeof(float) * 2 * mapECPin(this->_pin));
 
     // Buffer solution EC 1.413us/cm at 25C
     this->_kvalueLow              = 1.0;
@@ -96,8 +141,19 @@ DFRobot_EC::~DFRobot_EC()
 // Initialiser
 void DFRobot_EC::begin()
 {
+    Serial.print("_pin:");
+    Serial.println(this->_pin);
+
+    Serial.print("mapped:");
+    Serial.println(mapECPin(this->_pin));
+
+    Serial.print("_address:");
+    Serial.println(this->_address);
+
     // Read the calibrated K value from EEPROM
     EEPROM_read(this->_address, this->_kvalueLow); 
+    Serial.print("_kvalueLow:");
+    Serial.println(this->_kvalueLow);
     
     // If the values are all 255 then  write a default value in       
     if(EEPROM.read(this->_address)==0xFF && EEPROM.read(this->_address+1)==0xFF && EEPROM.read(this->_address+2)==0xFF && EEPROM.read(this->_address+3)==0xFF){
@@ -107,7 +163,9 @@ void DFRobot_EC::begin()
     }
 
     // Read the calibrated K value from EEPRM
-    EEPROM_read(this->_address+4, this->_kvalueHigh);     
+    EEPROM_read(this->_address+4, this->_kvalueHigh); 
+    Serial.print("_kvalueHigh:");
+    Serial.println(this->_kvalueHigh);    
     
     // If the values are all 255 then  write a default value in
     if(EEPROM.read(this->_address+4)==0xFF && EEPROM.read(this->_address+5)==0xFF && EEPROM.read(this->_address+6)==0xFF && EEPROM.read(this->_address+7)==0xFF){

--- a/DFRobot_EC.h
+++ b/DFRobot_EC.h
@@ -1,6 +1,5 @@
 /*
- * file DFRobot_EC.cpp
- * @ https://github.com/DFRobot/DFRobot_EC
+ * file DFRobot_EC.h * @ https://github.com/DFRobot/DFRobot_EC
  *
  * Arduino library for Gravity: Analog Electrical Conductivity Sensor / Meter Kit V2 (K=1), SKU: DFR0300
  *
@@ -15,6 +14,8 @@
  * Changes the memory addressing to allow multiple EC sensors
  */
 
+#ifndef _DFROBOT_EC_H_
+#define _DFROBOT_EC_H_
 
 #if ARDUINO >= 100
 #include "Arduino.h"
@@ -22,274 +23,70 @@
 #include "WProgram.h"
 #endif
 
-#include "DFRobot_EC.h"
-#include <EEPROM.h>
+#include <map>
 
-#define EEPROM_write(address, value) {int i = 0; byte *pp = (byte*)&(value);for(; i < sizeof(value); i++) EEPROM.write(address+i, pp[i]);}
-#define EEPROM_read(address, value)  {int i = 0; byte *pp = (byte*)&(value);for(; i < sizeof(value); i++) pp[i]=EEPROM.read(address+i);}
+// Map from pin to a address number to be multiplied by the number of bytes offset
+static std::map<uint8_t, uint8_t> EPinToAddressMap{
+	{A0, 0}, 
+	{A1, 1}, 
+	{A2, 2}, 
+	{A3, 3}, 
+	{A4, 4}, 
+	{A5, 5}, 
+	{A6, 6}, 
+	{A7, 7}, 
+	{A8, 8}, 
+	{A9, 9}, 
+	{A10, 10}, 
+	{A11, 11}, 
+    };
 
-// The start address of the K value stored in the EEPROM. Start at 96 after the 12 values for the pH sensors
-#define KVALUEADDR 96    
+// Length of the Serial CMD buffer
+#define ReceivedBufferLength 10  
 
-#define RES2 820.0
-#define ECREF 200.0
-
-// Default construtor to ensure backwards compatibility
-DFRobot_EC::DFRobot_EC()
+class DFRobot_EC
 {
-    // As no pin was provided we will use the data for pin A0
-    this->_pin            = A0;
+public:
+    // Construtors
+    DFRobot_EC();
+    DFRobot_EC(int ecPin);
 
-    // Set the address
-    // For each EC sensor we need to store 2 floats (EC 1.413us/cm and EC 12.88ms/cm)
-    // This will be 8byte per sensor and the largest arduino has 12 analogue ports
-    // So let's start at address 0 and go up by 8b for each analogue port. This will use upto 96b 
-    // For the EC library we will start after PH addresses
-    this->_address        = KVALUEADDR + (sizeof(float) * 2 *  this->_pin);
-
-    // Buffer solution EC 1.413us/cm at 25C
-    this->_kvalueLow              = 1.0;
-
-    // Buffer solution EC 12.88ms/cm at 25C
-    this->_kvalueHigh             = 1.0;
-
-    // Initialise the rest of the values with an initial starting value
-    this->_cmdReceivedBufferIndex = 0;
-    this->_voltage                = 0.0;
-    this->_temperature            = 25.0;
-    this->_ecvalue                = 0.0;
-    this->_kvalue                 = 1.0;
-} 
-
-// Updated construtor to allow multiple EC sensors
-DFRobot_EC::DFRobot_EC(int ecPin);
-{
-    // Set the pin to the supplied value
-    this->_pin                    = ecPin;
-
-    // Set the address
-    // For each EC sensor we need to store 2 floats (EC 1.413us/cm and EC 12.88ms/cm)
-    // This will be 8byte per sensor and the largest arduino has 12 analogue ports
-    // So let's start at address 0 and go up by 8b for each analogue port. This will use upto 96b 
-    // For the EC library we will start after PH addresses
-    this->_address                = KVALUEADDR + (sizeof(float) * 2 *  this->_pin);
-
-    // Buffer solution EC 1.413us/cm at 25C
-    this->_kvalueLow              = 1.0;
-
-    // Buffer solution EC 12.88ms/cm at 25C
-    this->_kvalueHigh             = 1.0;
-
-    // Initialise the rest of the values with an initial starting value
-    this->_cmdReceivedBufferIndex = 0;
-    this->_voltage                = 0.0;
-    this->_temperature            = 25.0;
-    this->_ecvalue                = 0.0;
-    this->_kvalue                 = 1.0;
-} 
-
-// Default destructor
-DFRobot_EC::~DFRobot_EC()
-{
-}
-
-// Initialiser
-void DFRobot_EC::begin()
-{
-    // Read the calibrated K value from EEPROM
-    EEPROM_read(this->_address, this->_kvalueLow); 
+    // Destructors
+    ~DFRobot_EC();
     
-    // If the values are all 255 then  write a default value in       
-    if(EEPROM.read(this->_address)==0xFF && EEPROM.read(this->_address+1)==0xFF && EEPROM.read(this->_address+2)==0xFF && EEPROM.read(this->_address+3)==0xFF){
-        // For new EEPROM, write default value( K = 1.0) to EEPROM
-        this->_kvalueLow = 1.0;                       
-        EEPROM_write(this->_address, this->_kvalueLow);
-    }
-
-    // Read the calibrated K value from EEPRM
-    EEPROM_read(this->_address+4, this->_kvalueHigh);     
+    // Initialization
+    void begin();
     
-    // If the values are all 255 then  write a default value in
-    if(EEPROM.read(this->_address+4)==0xFF && EEPROM.read(this->_address+5)==0xFF && EEPROM.read(this->_address+6)==0xFF && EEPROM.read(this->_address+7)==0xFF){
-        // For new EEPROM, write default value( K = 1.0) to EEPROM
-        this->_kvalueHigh = 1.0;                      
-        EEPROM_write(this->_address+4, this->_kvalueHigh);
-    }
+    // Calibration by Serial CMD
+    void calibration(float voltage, float temperature, char* cmd);
+    void calibration(float voltage, float temperature);
 
-    // Set default K value: K = kvalueLow
-    this->_kvalue =  this->_kvalueLow;                
-}
-
-// Function to read the EC value
-float DFRobot_EC::readEC(float voltage, float temperature)
-{
-    float value = 0;
-    float valueTemp = 0;
-
-    this->_rawEC = 1000 * voltage / RES2 / ECREF;
-    valueTemp = this->_rawEC * this->_kvalue;
-
-    // Automatic shift process
-    // First Range:(0,2); Second Range:(2,20)
-    if(valueTemp > 2.5){
-        this->_kvalue = this->_kvalueHigh;
-    }else if(valueTemp < 2.0){
-        this->_kvalue = this->_kvalueLow;
-    }
-
-    // Calculate the EC value after automatic shift
-    value = this->_rawEC * this->_kvalue;
-
-    // Temperature compensation
-    value = value / (1.0+0.0185*(temperature-25.0));  
-
-    // Store the EC value for Serial CMD calibration
-    this->_ecvalue = value;                           
+    // Voltage to EC value with temperature compensation
+    float readEC(float voltage, float temperature);
     
-    return value;
-}
+private:
+    int    _pin;
+    int    _address;
+    float  _ecvalue;
+    float  _kvalue;
+    float  _kvalueLow;
+    float  _kvalueHigh;
+    float  _voltage;
+    float  _temperature;
+    float  _rawEC;
 
-void DFRobot_EC::calibration(float voltage, float temperature,char* cmd)
-{   
-    this->_voltage = voltage;
-    this->_temperature = temperature;
-    strupr(cmd);
+    // Store the Serial CMD
+    char   _cmdReceivedBuffer[ReceivedBufferLength];  
+    byte   _cmdReceivedBufferIndex;
 
-    // If received Serial CMD from the serial monitor, enter into the calibration mode
-    ecCalibration(cmdParse(cmd));                     
-}
+private:
+    // Calibration process, wirte key parameters to EEPROM
+    void    ecCalibration(byte mode); 
 
-void DFRobot_EC::calibration(float voltage, float temperature)
-{   
-    this->_voltage = voltage;
-    this->_temperature = temperature;
-    
-    // If received Serial CMD from the serial monitor, enter into the calibration mode
-    if(cmdSerialDataAvailable() > 0)
-    {
-        ecCalibration(cmdParse());  
-    }
-}
+    boolean cmdSerialDataAvailable();
 
-boolean DFRobot_EC::cmdSerialDataAvailable()
-{
-    char cmdReceivedChar;
-    static unsigned long cmdReceivedTimeOut = millis();
-    while (Serial.available()>0) 
-    {
-        if(millis() - cmdReceivedTimeOut > 500U){
-            this->_cmdReceivedBufferIndex = 0;
-            memset(this->_cmdReceivedBuffer,0,(ReceivedBufferLength));
-        }
-        cmdReceivedTimeOut = millis();
-        cmdReceivedChar = Serial.read();
-        if(cmdReceivedChar == '\n' || this->_cmdReceivedBufferIndex==ReceivedBufferLength-1){
-            this->_cmdReceivedBufferIndex = 0;
-            strupr(this->_cmdReceivedBuffer);
-            return true;
-        }else{
-            this->_cmdReceivedBuffer[this->_cmdReceivedBufferIndex] = cmdReceivedChar;
-            this->_cmdReceivedBufferIndex++;
-        }
-    }
-    return false;
-}
+    byte    cmdParse(const char* cmd);
+    byte    cmdParse();
+};
 
-byte DFRobot_EC::cmdParse(const char* cmd)
-{
-    byte modeIndex = 0;
-    if(strstr(cmd, "ENTEREC")      != NULL){
-        modeIndex = 1;
-    }else if(strstr(cmd, "EXITEC") != NULL){
-        modeIndex = 3;
-    }else if(strstr(cmd, "CALEC")  != NULL){
-        modeIndex = 2;
-    }
-    return modeIndex;
-}
-
-byte DFRobot_EC::cmdParse()
-{
-    byte modeIndex = 0;
-    if(strstr(this->_cmdReceivedBuffer, "ENTEREC")     != NULL)
-        modeIndex = 1;
-    else if(strstr(this->_cmdReceivedBuffer, "EXITEC") != NULL)
-        modeIndex = 3;
-    else if(strstr(this->_cmdReceivedBuffer, "CALEC")  != NULL)
-        modeIndex = 2;
-    return modeIndex;
-}
-
-void DFRobot_EC::ecCalibration(byte mode)
-{
-    char *receivedBufferPtr;
-    static boolean ecCalibrationFinish  = 0;
-    static boolean enterCalibrationFlag = 0;
-    static float compECsolution;
-    float KValueTemp;
-    switch(mode){
-        case 0:
-        if(enterCalibrationFlag){
-            Serial.println(F(">>>Command Error<<<"));
-        }
-        break;
-        case 1:
-        enterCalibrationFlag = 1;
-        ecCalibrationFinish  = 0;
-        Serial.println();
-        Serial.println(F(">>>Enter EC Calibration Mode<<<"));
-        Serial.println(F(">>>Please put the probe into the 1413us/cm or 12.88ms/cm buffer solution<<<"));
-        Serial.println();
-        break;
-        case 2:
-        if(enterCalibrationFlag){
-            if((this->_rawEC>0.9)&&(this->_rawEC<1.9)){                         //recognize 1.413us/cm buffer solution
-                compECsolution = 1.413*(1.0+0.0185*(this->_temperature-25.0));  //temperature compensation
-            }else if((this->_rawEC>9)&&(this->_rawEC<16.8)){                    //recognize 12.88ms/cm buffer solution
-                compECsolution = 12.88*(1.0+0.0185*(this->_temperature-25.0));  //temperature compensation
-            }else{
-                Serial.print(F(">>>Buffer Solution Error Try Again<<<   "));
-                ecCalibrationFinish = 0;
-            }
-            KValueTemp = RES2*ECREF*compECsolution/1000.0/this->_voltage;       //calibrate the k value
-            if((KValueTemp>0.5) && (KValueTemp<1.5)){
-                Serial.println();
-                Serial.print(F(">>>Successful,K:"));
-                Serial.print(KValueTemp);
-                Serial.println(F(", Send EXITEC to Save and Exit<<<"));
-                if((this->_rawEC>0.9)&&(this->_rawEC<1.9)){
-                    this->_kvalueLow =  KValueTemp;
-                }else if((this->_rawEC>9)&&(this->_rawEC<16.8)){
-                    this->_kvalueHigh =  KValueTemp;
-                }
-                ecCalibrationFinish = 1;
-          }
-            else{
-                Serial.println();
-                Serial.println(F(">>>Failed,Try Again<<<"));
-                Serial.println();
-                ecCalibrationFinish = 0;
-            }
-        }
-        break;
-        case 3:
-        if(enterCalibrationFlag){
-                Serial.println();
-                if(ecCalibrationFinish){   
-                    if((this->_rawEC>0.9)&&(this->_rawEC<1.9)){
-                        EEPROM_write(this->_address, this->_kvalueLow);
-                    }else if((this->_rawEC>9)&&(this->_rawEC<16.8)){
-                        EEPROM_write(this->_address+4, this->_kvalueHigh);
-                    }
-                    Serial.print(F(">>>Calibration Successful"));
-                }else{
-                    Serial.print(F(">>>Calibration Failed"));
-                }
-                Serial.println(F(",Exit EC Calibration Mode<<<"));
-                Serial.println();
-                ecCalibrationFinish  = 0;
-                enterCalibrationFlag = 0;
-        }
-        break;
-    }
-}
+#endif

--- a/DFRobot_EC.h
+++ b/DFRobot_EC.h
@@ -1,5 +1,6 @@
 /*
- * file DFRobot_EC.h * @ https://github.com/DFRobot/DFRobot_EC
+ * file DFRobot_EC.cpp
+ * @ https://github.com/DFRobot/DFRobot_EC
  *
  * Arduino library for Gravity: Analog Electrical Conductivity Sensor / Meter Kit V2 (K=1), SKU: DFR0300
  *
@@ -14,8 +15,6 @@
  * Changes the memory addressing to allow multiple EC sensors
  */
 
-#ifndef _DFROBOT_EC_H_
-#define _DFROBOT_EC_H_
 
 #if ARDUINO >= 100
 #include "Arduino.h"
@@ -23,52 +22,274 @@
 #include "WProgram.h"
 #endif
 
-// Length of the Serial CMD buffer
-#define ReceivedBufferLength 10  
+#include "DFRobot_EC.h"
+#include <EEPROM.h>
 
-class DFRobot_EC
+#define EEPROM_write(address, value) {int i = 0; byte *pp = (byte*)&(value);for(; i < sizeof(value); i++) EEPROM.write(address+i, pp[i]);}
+#define EEPROM_read(address, value)  {int i = 0; byte *pp = (byte*)&(value);for(; i < sizeof(value); i++) pp[i]=EEPROM.read(address+i);}
+
+// The start address of the K value stored in the EEPROM. Start at 96 after the 12 values for the pH sensors
+#define KVALUEADDR 96    
+
+#define RES2 820.0
+#define ECREF 200.0
+
+// Default construtor to ensure backwards compatibility
+DFRobot_EC::DFRobot_EC()
 {
-public:
-    // Construtors
-    DFRobot_EC();
-    DFRobot_EC(int ecPin);
+    // As no pin was provided we will use the data for pin A0
+    this->_pin            = A0;
 
-    // Destructors
-    ~DFRobot_EC();
+    // Set the address
+    // For each EC sensor we need to store 2 floats (EC 1.413us/cm and EC 12.88ms/cm)
+    // This will be 8byte per sensor and the largest arduino has 12 analogue ports
+    // So let's start at address 0 and go up by 8b for each analogue port. This will use upto 96b 
+    // For the EC library we will start after PH addresses
+    this->_address        = KVALUEADDR + (sizeof(float) * 2 *  this->_pin);
+
+    // Buffer solution EC 1.413us/cm at 25C
+    this->_kvalueLow              = 1.0;
+
+    // Buffer solution EC 12.88ms/cm at 25C
+    this->_kvalueHigh             = 1.0;
+
+    // Initialise the rest of the values with an initial starting value
+    this->_cmdReceivedBufferIndex = 0;
+    this->_voltage                = 0.0;
+    this->_temperature            = 25.0;
+    this->_ecvalue                = 0.0;
+    this->_kvalue                 = 1.0;
+} 
+
+// Updated construtor to allow multiple EC sensors
+DFRobot_EC::DFRobot_EC(int ecPin);
+{
+    // Set the pin to the supplied value
+    this->_pin                    = ecPin;
+
+    // Set the address
+    // For each EC sensor we need to store 2 floats (EC 1.413us/cm and EC 12.88ms/cm)
+    // This will be 8byte per sensor and the largest arduino has 12 analogue ports
+    // So let's start at address 0 and go up by 8b for each analogue port. This will use upto 96b 
+    // For the EC library we will start after PH addresses
+    this->_address                = KVALUEADDR + (sizeof(float) * 2 *  this->_pin);
+
+    // Buffer solution EC 1.413us/cm at 25C
+    this->_kvalueLow              = 1.0;
+
+    // Buffer solution EC 12.88ms/cm at 25C
+    this->_kvalueHigh             = 1.0;
+
+    // Initialise the rest of the values with an initial starting value
+    this->_cmdReceivedBufferIndex = 0;
+    this->_voltage                = 0.0;
+    this->_temperature            = 25.0;
+    this->_ecvalue                = 0.0;
+    this->_kvalue                 = 1.0;
+} 
+
+// Default destructor
+DFRobot_EC::~DFRobot_EC()
+{
+}
+
+// Initialiser
+void DFRobot_EC::begin()
+{
+    // Read the calibrated K value from EEPROM
+    EEPROM_read(this->_address, this->_kvalueLow); 
     
-    // Initialization
-    void begin();
+    // If the values are all 255 then  write a default value in       
+    if(EEPROM.read(this->_address)==0xFF && EEPROM.read(this->_address+1)==0xFF && EEPROM.read(this->_address+2)==0xFF && EEPROM.read(this->_address+3)==0xFF){
+        // For new EEPROM, write default value( K = 1.0) to EEPROM
+        this->_kvalueLow = 1.0;                       
+        EEPROM_write(this->_address, this->_kvalueLow);
+    }
+
+    // Read the calibrated K value from EEPRM
+    EEPROM_read(this->_address+4, this->_kvalueHigh);     
     
-    // Calibration by Serial CMD
-    void calibration(float voltage, float temperature, char* cmd);
-    void calibration(float voltage, float temperature);
+    // If the values are all 255 then  write a default value in
+    if(EEPROM.read(this->_address+4)==0xFF && EEPROM.read(this->_address+5)==0xFF && EEPROM.read(this->_address+6)==0xFF && EEPROM.read(this->_address+7)==0xFF){
+        // For new EEPROM, write default value( K = 1.0) to EEPROM
+        this->_kvalueHigh = 1.0;                      
+        EEPROM_write(this->_address+4, this->_kvalueHigh);
+    }
 
-    // Voltage to EC value with temperature compensation
-    float readEC(float voltage, float temperature);
+    // Set default K value: K = kvalueLow
+    this->_kvalue =  this->_kvalueLow;                
+}
+
+// Function to read the EC value
+float DFRobot_EC::readEC(float voltage, float temperature)
+{
+    float value = 0;
+    float valueTemp = 0;
+
+    this->_rawEC = 1000 * voltage / RES2 / ECREF;
+    valueTemp = this->_rawEC * this->_kvalue;
+
+    // Automatic shift process
+    // First Range:(0,2); Second Range:(2,20)
+    if(valueTemp > 2.5){
+        this->_kvalue = this->_kvalueHigh;
+    }else if(valueTemp < 2.0){
+        this->_kvalue = this->_kvalueLow;
+    }
+
+    // Calculate the EC value after automatic shift
+    value = this->_rawEC * this->_kvalue;
+
+    // Temperature compensation
+    value = value / (1.0+0.0185*(temperature-25.0));  
+
+    // Store the EC value for Serial CMD calibration
+    this->_ecvalue = value;                           
     
-private:
-    int    _pin;
-    int    _address;
-    float  _ecvalue;
-    float  _kvalue;
-    float  _kvalueLow;
-    float  _kvalueHigh;
-    float  _voltage;
-    float  _temperature;
-    float  _rawEC;
+    return value;
+}
 
-    // Store the Serial CMD
-    char   _cmdReceivedBuffer[ReceivedBufferLength];  
-    byte   _cmdReceivedBufferIndex;
+void DFRobot_EC::calibration(float voltage, float temperature,char* cmd)
+{   
+    this->_voltage = voltage;
+    this->_temperature = temperature;
+    strupr(cmd);
 
-private:
-    // Calibration process, wirte key parameters to EEPROM
-    void    ecCalibration(byte mode); 
+    // If received Serial CMD from the serial monitor, enter into the calibration mode
+    ecCalibration(cmdParse(cmd));                     
+}
 
-    boolean cmdSerialDataAvailable();
+void DFRobot_EC::calibration(float voltage, float temperature)
+{   
+    this->_voltage = voltage;
+    this->_temperature = temperature;
+    
+    // If received Serial CMD from the serial monitor, enter into the calibration mode
+    if(cmdSerialDataAvailable() > 0)
+    {
+        ecCalibration(cmdParse());  
+    }
+}
 
-    byte    cmdParse(const char* cmd);
-    byte    cmdParse();
-};
+boolean DFRobot_EC::cmdSerialDataAvailable()
+{
+    char cmdReceivedChar;
+    static unsigned long cmdReceivedTimeOut = millis();
+    while (Serial.available()>0) 
+    {
+        if(millis() - cmdReceivedTimeOut > 500U){
+            this->_cmdReceivedBufferIndex = 0;
+            memset(this->_cmdReceivedBuffer,0,(ReceivedBufferLength));
+        }
+        cmdReceivedTimeOut = millis();
+        cmdReceivedChar = Serial.read();
+        if(cmdReceivedChar == '\n' || this->_cmdReceivedBufferIndex==ReceivedBufferLength-1){
+            this->_cmdReceivedBufferIndex = 0;
+            strupr(this->_cmdReceivedBuffer);
+            return true;
+        }else{
+            this->_cmdReceivedBuffer[this->_cmdReceivedBufferIndex] = cmdReceivedChar;
+            this->_cmdReceivedBufferIndex++;
+        }
+    }
+    return false;
+}
 
-#endif
+byte DFRobot_EC::cmdParse(const char* cmd)
+{
+    byte modeIndex = 0;
+    if(strstr(cmd, "ENTEREC")      != NULL){
+        modeIndex = 1;
+    }else if(strstr(cmd, "EXITEC") != NULL){
+        modeIndex = 3;
+    }else if(strstr(cmd, "CALEC")  != NULL){
+        modeIndex = 2;
+    }
+    return modeIndex;
+}
+
+byte DFRobot_EC::cmdParse()
+{
+    byte modeIndex = 0;
+    if(strstr(this->_cmdReceivedBuffer, "ENTEREC")     != NULL)
+        modeIndex = 1;
+    else if(strstr(this->_cmdReceivedBuffer, "EXITEC") != NULL)
+        modeIndex = 3;
+    else if(strstr(this->_cmdReceivedBuffer, "CALEC")  != NULL)
+        modeIndex = 2;
+    return modeIndex;
+}
+
+void DFRobot_EC::ecCalibration(byte mode)
+{
+    char *receivedBufferPtr;
+    static boolean ecCalibrationFinish  = 0;
+    static boolean enterCalibrationFlag = 0;
+    static float compECsolution;
+    float KValueTemp;
+    switch(mode){
+        case 0:
+        if(enterCalibrationFlag){
+            Serial.println(F(">>>Command Error<<<"));
+        }
+        break;
+        case 1:
+        enterCalibrationFlag = 1;
+        ecCalibrationFinish  = 0;
+        Serial.println();
+        Serial.println(F(">>>Enter EC Calibration Mode<<<"));
+        Serial.println(F(">>>Please put the probe into the 1413us/cm or 12.88ms/cm buffer solution<<<"));
+        Serial.println();
+        break;
+        case 2:
+        if(enterCalibrationFlag){
+            if((this->_rawEC>0.9)&&(this->_rawEC<1.9)){                         //recognize 1.413us/cm buffer solution
+                compECsolution = 1.413*(1.0+0.0185*(this->_temperature-25.0));  //temperature compensation
+            }else if((this->_rawEC>9)&&(this->_rawEC<16.8)){                    //recognize 12.88ms/cm buffer solution
+                compECsolution = 12.88*(1.0+0.0185*(this->_temperature-25.0));  //temperature compensation
+            }else{
+                Serial.print(F(">>>Buffer Solution Error Try Again<<<   "));
+                ecCalibrationFinish = 0;
+            }
+            KValueTemp = RES2*ECREF*compECsolution/1000.0/this->_voltage;       //calibrate the k value
+            if((KValueTemp>0.5) && (KValueTemp<1.5)){
+                Serial.println();
+                Serial.print(F(">>>Successful,K:"));
+                Serial.print(KValueTemp);
+                Serial.println(F(", Send EXITEC to Save and Exit<<<"));
+                if((this->_rawEC>0.9)&&(this->_rawEC<1.9)){
+                    this->_kvalueLow =  KValueTemp;
+                }else if((this->_rawEC>9)&&(this->_rawEC<16.8)){
+                    this->_kvalueHigh =  KValueTemp;
+                }
+                ecCalibrationFinish = 1;
+          }
+            else{
+                Serial.println();
+                Serial.println(F(">>>Failed,Try Again<<<"));
+                Serial.println();
+                ecCalibrationFinish = 0;
+            }
+        }
+        break;
+        case 3:
+        if(enterCalibrationFlag){
+                Serial.println();
+                if(ecCalibrationFinish){   
+                    if((this->_rawEC>0.9)&&(this->_rawEC<1.9)){
+                        EEPROM_write(this->_address, this->_kvalueLow);
+                    }else if((this->_rawEC>9)&&(this->_rawEC<16.8)){
+                        EEPROM_write(this->_address+4, this->_kvalueHigh);
+                    }
+                    Serial.print(F(">>>Calibration Successful"));
+                }else{
+                    Serial.print(F(">>>Calibration Failed"));
+                }
+                Serial.println(F(",Exit EC Calibration Mode<<<"));
+                Serial.println();
+                ecCalibrationFinish  = 0;
+                enterCalibrationFlag = 0;
+        }
+        break;
+    }
+}

--- a/DFRobot_EC.h
+++ b/DFRobot_EC.h
@@ -8,6 +8,10 @@
  *
  * version  V1.01
  * date  2018-06
+ * 
+ * version  V1.1
+ * date  2020-04
+ * Changes the memory addressing to allow multiple EC sensors
  */
 
 #ifndef _DFROBOT_EC_H_
@@ -19,19 +23,32 @@
 #include "WProgram.h"
 #endif
 
-#define ReceivedBufferLength 10  //length of the Serial CMD buffer
+// Length of the Serial CMD buffer
+#define ReceivedBufferLength 10  
 
 class DFRobot_EC
 {
 public:
+    // Construtors
     DFRobot_EC();
-    ~DFRobot_EC();
-    void    calibration(float voltage, float temperature,char* cmd);        //calibration by Serial CMD
-    void    calibration(float voltage, float temperature);                  //calibration by Serial CMD
-    float   readEC(float voltage, float temperature);                       // voltage to EC value, with temperature compensation
-    void    begin();                                                        //initialization
+    DFRobot_EC(int ecPin);
 
+    // Destructors
+    ~DFRobot_EC();
+    
+    // Initialization
+    void begin();
+    
+    // Calibration by Serial CMD
+    void calibration(float voltage, float temperature, char* cmd);
+    void calibration(float voltage, float temperature);
+
+    // Voltage to EC value with temperature compensation
+    float readEC(float voltage, float temperature);
+    
 private:
+    int    _pin;
+    int    _address;
     float  _ecvalue;
     float  _kvalue;
     float  _kvalueLow;
@@ -40,12 +57,16 @@ private:
     float  _temperature;
     float  _rawEC;
 
-    char   _cmdReceivedBuffer[ReceivedBufferLength];  //store the Serial CMD
+    // Store the Serial CMD
+    char   _cmdReceivedBuffer[ReceivedBufferLength];  
     byte   _cmdReceivedBufferIndex;
 
 private:
+    // Calibration process, wirte key parameters to EEPROM
+    void    ecCalibration(byte mode); 
+
     boolean cmdSerialDataAvailable();
-    void    ecCalibration(byte mode); // calibration process, wirte key parameters to EEPROM
+
     byte    cmdParse(const char* cmd);
     byte    cmdParse();
 };

--- a/DFRobot_EC.h
+++ b/DFRobot_EC.h
@@ -23,26 +23,15 @@
 #include "WProgram.h"
 #endif
 
-#include <map>
-
-// Map from pin to a address number to be multiplied by the number of bytes offset
-static std::map<uint8_t, uint8_t> EPinToAddressMap{
-	{A0, 0}, 
-	{A1, 1}, 
-	{A2, 2}, 
-	{A3, 3}, 
-	{A4, 4}, 
-	{A5, 5}, 
-	{A6, 6}, 
-	{A7, 7}, 
-	{A8, 8}, 
-	{A9, 9}, 
-	{A10, 10}, 
-	{A11, 11}, 
-    };
-
 // Length of the Serial CMD buffer
 #define ReceivedBufferLength 10  
+
+/**
+ * Maps the pin (A0,A1..A11) to a number 0-11 so the address can be determined
+ * @param ecPin the pin the EC sensor is attached to
+ * @return the address multiplier
+ */
+uint8_t mapECPin(uint8_t ecPin);
 
 class DFRobot_EC
 {

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ This is the sample code for Gravity: Analog Electrical Conductivity Sensor / Met
 ## Methods
 
 ```C++
+/*
+ * @brief The new optional constructor to allow multiple EC sensors
+ *
+ * @param ecPin: The pin of the EC sensor i.e. A0
+ */
+DFRobot_EC(int ecPin);
 
 /*
  * @brief Init The Analog Electrical Conductivity Sensor
@@ -54,6 +60,9 @@ Meag2560 |      √       |             |            |
 
 - date 2018-11-6
 - version V1.0
+- date 2020-04-18
+- version V1.1
+    - Update to allow multiple EC sensors each with their own calibration
 
 ## Credits
 


### PR DESCRIPTION
Writes the calibration for each ECsensor to it's own memory address linked to the analogue pin number. This is compatible with the pH sensor library as it writes the calibrations after the pH ones.